### PR TITLE
店舗のサインアップを追記

### DIFF
--- a/app/controllers/stores/registrations_controller.rb
+++ b/app/controllers/stores/registrations_controller.rb
@@ -39,7 +39,9 @@ class Stores::RegistrationsController < Devise::RegistrationsController
   # protected
 
   def sign_up_params
-    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail) }
+    devise_parameter_sanitizer.for(:sign_up) do |u|
+      u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
+    end
     super
   end
 

--- a/app/controllers/stores/registrations_controller.rb
+++ b/app/controllers/stores/registrations_controller.rb
@@ -38,6 +38,13 @@ class Stores::RegistrationsController < Devise::RegistrationsController
 
   # protected
 
+  def sign_up_params
+    devise_parameter_sanitizer.for(:sign_up) {
+       |u| u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
+    }
+    super
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.for(:sign_up) << :attribute

--- a/app/controllers/stores/registrations_controller.rb
+++ b/app/controllers/stores/registrations_controller.rb
@@ -39,9 +39,7 @@ class Stores::RegistrationsController < Devise::RegistrationsController
   # protected
 
   def sign_up_params
-    devise_parameter_sanitizer.for(:sign_up) {
-      | u | u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
-    }
+    devise_parameter_sanitizer.for(:sign_up) | u | u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
     super
   end
 

--- a/app/controllers/stores/registrations_controller.rb
+++ b/app/controllers/stores/registrations_controller.rb
@@ -39,9 +39,8 @@ class Stores::RegistrationsController < Devise::RegistrationsController
   # protected
 
   def sign_up_params
-    devise_parameter_sanitizer.for(:sign_up) {
-       |u| u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
-    }
+    devise_parameter_sanitizer.for(:sign_up) | u |
+      u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
     super
   end
 

--- a/app/controllers/stores/registrations_controller.rb
+++ b/app/controllers/stores/registrations_controller.rb
@@ -39,8 +39,9 @@ class Stores::RegistrationsController < Devise::RegistrationsController
   # protected
 
   def sign_up_params
-    devise_parameter_sanitizer.for(:sign_up) | u |
-      u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
+    devise_parameter_sanitizer.for(:sign_up) {
+      | u | u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
+    }
     super
   end
 

--- a/app/controllers/stores/registrations_controller.rb
+++ b/app/controllers/stores/registrations_controller.rb
@@ -39,7 +39,7 @@ class Stores::RegistrationsController < Devise::RegistrationsController
   # protected
 
   def sign_up_params
-    devise_parameter_sanitizer.for(:sign_up) | u | u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail)
+    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:email, :password, :name, :address, :phone_number, :budget, :detail) }
     super
   end
 

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -9,5 +9,4 @@ class Store < ActiveRecord::Base
   validates :phone_number, presence: true, length: { maximum: 20 }
   validates :budget, presence: true, length: { maximum: 10 }
   validates :detail, presence: true, length: { maximum: 2000 }
-
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -3,4 +3,11 @@ class Store < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :address, presence: true, length: { maximum: 200 }
+  validates :phone_number, presence: true, length: { maximum: 20 }
+  validates :budget, presence: true, length: { maximum: 10 }
+  validates :detail, presence: true, length: { maximum: 2000 }
+
 end

--- a/app/views/stores/registrations/new.html.erb
+++ b/app/views/stores/registrations/new.html.erb
@@ -4,6 +4,11 @@
   <%= devise_error_messages! %>
 
   <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true %>
   </div>
@@ -19,6 +24,26 @@
   <div class="field">
     <%= f.label :password_confirmation %><br />
     <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :address %><br />
+    <%= f.text_field :address %>
+  </div>
+
+  <div class="field">
+    <%= f.label :phone_number %><br />
+    <%= f.text_field :phone_number %>
+  </div>
+
+  <div class="field">
+    <%= f.label :budget %><br />
+    <%= f.text_field :budget %>
+  </div>
+
+  <div class="area">
+    <%= f.label :detail %><br />
+    <%= f.text_area :detail, size: "30×48" %>
   </div>
 
   <div class="actions">

--- a/db/migrate/20151225070123_add_column_to_store.rb
+++ b/db/migrate/20151225070123_add_column_to_store.rb
@@ -1,0 +1,9 @@
+class AddColumnToStore < ActiveRecord::Migration
+  def change
+    add_column :stores, :name, :text, null: false
+    add_column :stores, :address, :text, null: false
+    add_column :stores, :phone_number, :string, null: false, default: ""
+    add_column :stores, :budget, :integer
+    add_column :stores, :detail, :text, null: false
+  end
+end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Store, type: :model do
     # 2.
     # cannot substitute phone_number
     # caused by string type?
+    # 3.
+    # long long line
     let(:params) { { email: 'true_store@example.com', password: '01234567', name: 'true store', address: '高知県香美市土佐山田町宮ノ口185', phone_number: `0120-00-0000`, budget: '3000', detail: 'This store is true.' } }
     shared_examples 'not be valid' do
       it { expect(store).not_to be_valid }

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -3,22 +3,22 @@ require 'rails_helper'
 RSpec.describe Store, type: :model do
   describe 'with validation' do
     let(:store) { Store.new(params) }
-    # WIP
-    # 1.
-    # budget is integer type
-    # but now value is string type
-    # 2.
-    # cannot substitute phone_number
-    # caused by string type?
-    # 3.
-    # long long line
-    let(:params) { { email: 'true_store@example.com', password: '01234567', name: 'true store', address: '高知県香美市土佐山田町宮ノ口185', phone_number: `0120-00-0000`, budget: '3000', detail: 'This store is true.' } }
+    let(:params) do
+      hash = {}
+      hash[:email] = 'true_store@example.com'
+      hash[:password] = '01234567'
+      hash[:name] = 'true store'
+      hash[:address] = '高知県香美市土佐山田町宮ノ口185'
+      hash[:phone_number] = '0120-00-0000'
+      hash[:budget] = 3000
+      hash[:detail] = 'This store is true.'
+      hash
+    end
     shared_examples 'not be valid' do
       it { expect(store).not_to be_valid }
     end
     context 'when true case' do
       it 'be valid' do
-        store.phone_number = '1234-56-7890'
         expect(store).to be_valid
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe Store, type: :model do
       end
       context 'when budget is not present' do
         before do
-          digit11 = 1 * 11
+          digit11 = 10**10
           store.budget = digit11
         end
         it_behaves_like 'not be valid'

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Store, type: :model do
+  describe 'with validation' do
+    let(:store) { Store.new(params) }
+    # WIP
+    # 1.
+    # budget is integer type
+    # but now value is string type
+    # 2.
+    # cannot substitute phone_number
+    # caused by string type?
+    let(:params) { { email: 'true_store@example.com', password: '01234567', name: 'true store', address: '高知県香美市土佐山田町宮ノ口185', phone_number: `0120-00-0000`, budget: '3000', detail: 'This store is true.' } }
+    shared_examples 'not be valid' do
+      it { expect(store).not_to be_valid }
+    end
+    context 'when true case' do
+      it 'be valid' do
+        store.phone_number = '1234-56-7890'
+        expect(store).to be_valid
+      end
+    end
+    describe 'with present' do
+      context 'when name is not present' do
+        before do
+          store.name = ''
+        end
+        it_behaves_like 'not be valid'
+      end
+      context 'when address is not present' do
+        before do
+          store.address = ''
+        end
+        it_behaves_like 'not be valid'
+      end
+      context 'when phone_number is not present' do
+        before do
+          store.phone_number = ''
+        end
+        it_behaves_like 'not be valid'
+      end
+      context 'when budget is not present' do
+        before do
+          store.budget = ''
+        end
+        it_behaves_like 'not be valid'
+      end
+      context 'when detail is not present' do
+        before do
+          store.detail = ''
+        end
+        it_behaves_like 'not be valid'
+      end
+    end
+    describe 'with maximum length' do
+      context 'when name is not present' do
+        before do
+          str51 = 'n' * 51
+          store.name = str51
+        end
+        it_behaves_like 'not be valid'
+      end
+      context 'when addless is not present' do
+        before do
+          str201 = 'n' * 201
+          store.address = str201
+        end
+        it_behaves_like 'not be valid'
+      end
+      context 'when phone_number is not present' do
+        before do
+          str21 = 'n' * 21
+          store.phone_number = str21
+        end
+        it_behaves_like 'not be valid'
+      end
+      context 'when budget is not present' do
+        before do
+          digit11 = 1 * 11
+          store.budget = digit11
+        end
+        it_behaves_like 'not be valid'
+      end
+      context 'when detail is not present' do
+        before do
+          str2001 = 'n' * 2001
+          store.detail = str2001
+        end
+        it_behaves_like 'not be valid'
+      end
+    end
+  end
+end


### PR DESCRIPTION
* 変更点
- storesのマイグレーションにname, address, phone_number, budget, detailを追加
- それぞれのバリデーションをモデルに追記
- それぞれの値をサインアップ時に利用できるようにコントローラに追記
- それぞれの値を入力・取得できるようにビューに追記
- Storeモデルのテストを追加